### PR TITLE
Fix/radio button group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ This changelog references the relevant changes done between versions.
 
 To get the diff for a specific change, go to https://github.com/LIN3S/FrontFoundation/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/LIN3S/FrontFoundation/compare/v0.5.0...v0.6.0
-
+* 0.18.12
+    * Radio group name added to reference it directly
 * 0.18.11
     * Fixed form group radio data validate
 * 0.18.10

--- a/src/templates/twig/atoms/form_radio.html.twig
+++ b/src/templates/twig/atoms/form_radio.html.twig
@@ -16,18 +16,16 @@
     @param radio_modifiers          string=null
     @param radio_checked            int=0
     @param radio_value              string=null
-    @param radio_id                 string=null
     @param radio_name               string=null
     @param radio_content            html|raw*
 #}
 
 {% set class = 'class="form-radio js-form-radio ' ~ radio_class_name|default ~ ' ' ~ radio_modifiers|default ~ '"' %}
-{% set id = radio_id|default ? 'id=' ~ radio_id %}
-{% set name = radio_name|default(radio_id|default) ? 'name=' ~ radio_name|default(radio_id|default) %}
+{% set name = radio_name|default ? 'name=' ~ radio_name %}
 {% set checked = radio_checked|default(0) ? 'checked' %}
 {% set value = radio_value|default ? 'value="' ~ radio_value ~ '"' %}
 
 <label {{ class|raw }} tabindex="0">
-    <input type="radio" class="form-radio__circle" {{ id }} {{ name }} {{ value|raw }} {{ checked }}/>
+    <input type="radio" class="form-radio__circle" {{ name }} {{ value|raw }} {{ checked }}/>
     <span class="form-radio__content">{{ radio_content|raw }}</span>
 </label>

--- a/src/templates/twig/components/form_group_radio.html.twig
+++ b/src/templates/twig/components/form_group_radio.html.twig
@@ -32,6 +32,7 @@
     @param radio_validate                           int=0
     @param radio_validation_pattern                 string=null
     @param radio_validation_type                    string=null
+    @param group_name                               string*
 
 #}
 
@@ -65,12 +66,12 @@
     {% if radio_validate|default(0) %}
         {% set required = radio_required|default(0) ? 'required' %}
 
-        <input class="form-group-radio__hidden" type="hidden" {{ required }}
+        <input class="form-group-radio__hidden" type="hidden" name="{{ group_name }}" {{ required }}
                 {% if radio_validate|default(0) %} data-validate
             {% if radio_validation_pattern|default %}
                 data-validate-pattern="{{ radio_validation_pattern }}"
             {% elseif radio_validation_type|default %}
-                data-validate-{{ radio_validation_type }}
+                data-validate="{{ radio_validation_type }}"
             {% endif %}
                 {% endif %}/>
     {% endif %}

--- a/src/templates/twig/components/form_group_radio.html.twig
+++ b/src/templates/twig/components/form_group_radio.html.twig
@@ -32,7 +32,7 @@
     @param radio_validate                           int=0
     @param radio_validation_pattern                 string=null
     @param radio_validation_type                    string=null
-    @param group_name                               string*
+    @param radio_group_id                           string=null
 
 #}
 
@@ -65,8 +65,10 @@
 
     {% if radio_validate|default(0) %}
         {% set required = radio_required|default(0) ? 'required' %}
+        {% set radio_group_name = radio_group_name|default(radio_group_id|default) ? 'name=' ~ radio_group_name|default(radio_group_id|default) %}
+        {% set radio_group_id = radio_group_id|default ? 'id=' ~ radio_group_id %}
 
-        <input class="form-group-radio__hidden" type="hidden" name="{{ group_name }}" {{ required }}
+        <input class="form-group-radio__hidden" type="hidden" {{ radio_group_name }} {{ radio_group_id }} {{ required }}
                 {% if radio_validate|default(0) %} data-validate
             {% if radio_validation_pattern|default %}
                 data-validate-pattern="{{ radio_validation_pattern }}"

--- a/tests/app/src/templates/index.html.twig
+++ b/tests/app/src/templates/index.html.twig
@@ -145,14 +145,17 @@
                         <div id="components-radio" class="section__element">
                             <h4 class="section__title">2.3.2 - Radio</h4>
                             {% include '@lin3s_front_foundation/components/form_group_radio.html.twig' with {
-                                radio_id: 'genre',
-                                radio_label_title: 'Genre',
+                                radio_id: 'gender',
+                                radio_label_title: 'Gender',
+                                radio_group_id: 'gender_group',
+                                radio_validate: 1,
+                                radio_validation_type: 'any',
                                 radio_radios: [{
                                     radio_content: 'Male',
-                                    radio_value: 0
+                                    radio_value: 'male',
                                 }, {
                                     radio_content: 'Female',
-                                    radio_value: 1
+                                    radio_value: 'female'
                                 }]
                             } %}
                         </div>


### PR DESCRIPTION
Radio button group had no name in the `input` field, so it could not be referenced directly from `JS`.